### PR TITLE
feat: Add support for hostDirectives

### DIFF
--- a/scripts/__snapshots__/main.test.js.snap
+++ b/scripts/__snapshots__/main.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generateDeepNestedRoutes should resolve compact components from routes 1`] = `
 "flowchart LR
@@ -442,6 +442,13 @@ Root --o NbResetPasswordComponent(NbResetPasswordComponent)
 DashboardComponent --- NbThemeService{{NbThemeService}}
 DashboardComponent --- SolarData{{SolarData}}
 NotFoundComponent --- NbMenuService{{NbMenuService}}"
+`;
+
+exports[`generateHostDirectives should resolve host directives from components 1`] = `
+"flowchart LR
+Root --o HostComponent(HostComponent)
+HostComponent ---OtherComponent([OtherComponent])
+HostComponent -.-> MyDirective{{MyDirective}}"
 `;
 
 exports[`generateLazyComponents should resolve components from routes 1`] = `

--- a/scripts/main.helper.js
+++ b/scripts/main.helper.js
@@ -57,6 +57,10 @@ export const generateMermaid = (routes) => {
                         // Import (solid line with square brackets)
                         mermaidLines.push(`${parentNode} ---${formattedComponentName}([${componentName}])`);
                         break;
+                    case 'hostDirective':
+                        // Host Directive (dotted line with normal arrow and curly braces)
+                        mermaidLines.push(`${parentNode} -.-> ${formattedComponentName}{{${componentName}}}`);
+                        break;
                     default:
                         // Standard component (solid line with open arrowhead)
                         mermaidLines.push(`${parentNode} --o ${formattedComponentName}(${componentName})`);

--- a/scripts/main.test.js
+++ b/scripts/main.test.js
@@ -118,6 +118,18 @@ describe('generateDeepNestedRoutes', () => {
     });
 });
 
+describe('generateHostDirectives', () => {
+    it('should resolve host directives from components', () => {
+        const components = main({
+            basePath: "./test-data/route-definitions/host-directives-test",
+            routesFilePath: 'app.routes.ts',
+            withServices: true,
+            withNestedDependencies: true
+        });
+        expect(components).toMatchSnapshot();
+    });
+});
+
 describe('generateLazyComponents', () => {
     it('should resolve satisfy components from routes', () => {
         const components = main({

--- a/scripts/template.helper.js
+++ b/scripts/template.helper.js
@@ -32,57 +32,65 @@ const loadDependencies = (c, withNestedDependencies, recursionDepth) => {
         c.componentName = nameMatches[0][1];
     }
 
-    const importNodes = parse(fileContent, { range: true }).body
-        .filter(n => (n.type === 'ExportDefaultDeclaration' || n.type === 'ExportNamedDeclaration') && n.declaration?.decorators)?.flatMap(n => n
-            .declaration.decorators.filter(d => d.expression.callee?.name === 'Component')?.[0]
-            ?.expression.arguments[0].properties.filter(n => n.key.name === 'imports' || n.key.name === 'hostDirectives')?.[0]
-            ?.value.elements);
+    const ast = parse(fileContent, { range: true });
+    const componentDecorator = ast.body
+        .filter(n => (n.type === 'ExportDefaultDeclaration' || n.type === 'ExportNamedDeclaration') && n.declaration?.decorators)
+        .flatMap(n => n.declaration.decorators)
+        .find(d => d.expression.callee?.name === 'Component');
 
-    // ToDo: add tests for this
+    const decoratorProperties = componentDecorator?.expression.arguments[0].properties;
+
+    const importNodes = decoratorProperties?.find(p => p.key.name === 'imports')?.value.elements || [];
+    const hostDirectiveNodes = decoratorProperties?.find(p => p.key.name === 'hostDirectives')?.value.elements || [];
+
     const components = handleRoutes(importNodes, fileContent, withNestedDependencies, path.join(path.relative(cwd, p), "../"), c.componentName, recursionDepth);
 
     if (!withNestedDependencies) {
         return [c, ...components];
     }
 
-    // Extract both direct identifiers and hostDirective property expressions
-    const identifierNodes = importNodes.filter(n => 
-        n?.type === 'Identifier' || 
+    const importedComponents = extractDependencies(importNodes, 'import', fileContent, c.componentName, path.relative(cwd, p));
+    const hostDirectives = extractDependencies(hostDirectiveNodes, 'hostDirective', fileContent, c.componentName, path.relative(cwd, p));
+
+    components.push(...importedComponents, ...hostDirectives);
+
+    const x = addTemplateElements(components, recursionDepth + 1);
+    return [c, ...x];
+}
+
+const extractDependencies = (nodes, type, fileContent, parentComponent, relativePath) => {
+    if (!nodes || nodes.length === 0) {
+        return [];
+    }
+
+    const identifierNodes = nodes.filter(n =>
+        n?.type === 'Identifier' ||
         (n?.type === 'ObjectExpression' && n.properties.some(p => p.key.name === 'directive'))
     );
 
-    if (identifierNodes?.length) {
-        try {
-            // Extract component names from both regular imports and hostDirectives
-            const importsContent = identifierNodes.map(e => {
-                if (e.type === 'Identifier') {
-                    return e.name;
-                } else if (e.type === 'ObjectExpression') {
-                    const directiveProp = e.properties.find(p => p.key.name === 'directive');
-                    return directiveProp?.value?.name;
-                }
-                return null;
-            }).filter(Boolean);
-
-            importsContent.forEach(componentName => {
-                const comp = handleComponent(componentName, fileContent, c.componentName, path.relative(cwd, p));
-                if (comp) {
-                    components.push(comp);
-                }
-            });
-
-            const x = addTemplateElements(components, recursionDepth + 1);
-            return [c, ...x];
-        } catch {
-            console.error(`Could not resolve imports for component: ${c.componentName}`);
+    const dependencyNames = identifierNodes.map(e => {
+        if (e.type === 'Identifier') {
+            return e.name;
+        } else if (e.type === 'ObjectExpression') {
+            const directiveProp = e.properties.find(p => p.key.name === 'directive');
+            return directiveProp?.value?.name;
         }
-    }
+        return null;
+    }).filter(Boolean);
 
-    return [c, ...components];
-}
+    return dependencyNames.map(componentName => {
+        const comp = handleComponent(componentName, fileContent, parentComponent, relativePath);
+        if (comp) {
+            comp.type = type;
+            return comp;
+        }
+        return null;
+    }).filter(Boolean);
+};
+
 
 const handleRoutes = (importNodes, fileContent, withNestedDependencies, p, componentName, recursionDepth) => {
-    const provideRouter = importNodes.filter(n => n?.type === 'CallExpression' && n.callee.name === 'provideRouter')?.[0]?.arguments?.[0];
+    const provideRouter = importNodes?.filter(n => n?.type === 'CallExpression' && n.callee.name === 'provideRouter')?.[0]?.arguments?.[0];
 
     if (provideRouter?.type === 'ArrayExpression') {
         const routes = extractRoutesFromTS(fileContent.substring(...provideRouter.range), componentName);

--- a/test-data/route-definitions/host-directives-test/app.routes.ts
+++ b/test-data/route-definitions/host-directives-test/app.routes.ts
@@ -1,0 +1,9 @@
+import { Routes } from '@angular/router';
+import { HostComponent } from './host.component';
+
+export const routes: Routes = [
+  {
+    path: '',
+    component: HostComponent,
+  },
+];

--- a/test-data/route-definitions/host-directives-test/host.component.ts
+++ b/test-data/route-definitions/host-directives-test/host.component.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+import { MyDirective } from './my.directive';
+import { OtherComponent } from './other.component';
+
+@Component({
+  selector: 'app-host',
+  standalone: true,
+  imports: [OtherComponent],
+  hostDirectives: [MyDirective],
+  template: ``,
+})
+export class HostComponent {}

--- a/test-data/route-definitions/host-directives-test/my.directive.ts
+++ b/test-data/route-definitions/host-directives-test/my.directive.ts
@@ -1,0 +1,9 @@
+import { Directive } from '@angular/core';
+
+@Directive({
+  selector: '[myDirective]',
+  standalone: true,
+})
+export class MyDirective {
+  constructor() {}
+}

--- a/test-data/route-definitions/host-directives-test/other.component.ts
+++ b/test-data/route-definitions/host-directives-test/other.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-other',
+  standalone: true,
+  template: ``,
+})
+export class OtherComponent {}


### PR DESCRIPTION
This change adds support for visualizing `hostDirectives` in the generated Mermaid diagram.

- Refactored the component parsing logic to correctly identify both `imports` and `hostDirectives` properties in a component's decorator.
- Introduced a new element type, `hostDirective`, to distinguish them from regular `imports`.
- Updated the Mermaid diagram generation to render `hostDirectives` with a unique style (a dotted line with an arrow and curly braces).
- Added a new test case with a component using `hostDirectives` to verify the functionality and prevent regressions.